### PR TITLE
Fix time_ss in renderTime

### DIFF
--- a/api/inc/models/gtfs.php
+++ b/api/inc/models/gtfs.php
@@ -57,7 +57,7 @@ class GTFS {
         $time_sec -= $day_full_sec;
         $time_hh = floor($time_sec / 3600);
         $time_mm = floor(($time_sec - $time_hh * 3600) / 60);
-        $time_ss = $time_sec - ($time_mm * 60);
+        $time_ss = $time_sec - $time_hh * 3600 - $time_mm * 60;
         
         return sprintf('%02d:%02d:%02d', $time_hh, $time_mm, $time_ss);
     }


### PR DESCRIPTION
If hms is "29:51:55" the renderTime function returns "05:51:18055".
With this change it will return "05:51:55".
